### PR TITLE
fix: clean up unused imports and shader typing

### DIFF
--- a/src/components/RoadmapCard/RoadmapCard.tsx
+++ b/src/components/RoadmapCard/RoadmapCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { PhaseItem } from '../PhaseItem/PhaseItem';
 import styles from './RoadmapCard.module.scss';
 

--- a/src/components/ThreeDBackground/ThreeDBackground.tsx
+++ b/src/components/ThreeDBackground/ThreeDBackground.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useMemo } from 'react';
-import { Canvas, useFrame, useThree, extend } from '@react-three/fiber';
+import React, { useRef } from 'react';
+import { Canvas, useFrame, useThree, extend, type Object3DNode } from '@react-three/fiber';
 import * as THREE from 'three';
 import styles from './ThreeDBackground.module.scss';
 
@@ -130,11 +130,12 @@ class TVStaticShaderMaterial extends THREE.ShaderMaterial {
 extend({ TVStaticShaderMaterial });
 
 // Declare the extended material for TypeScript
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      tVStaticShaderMaterial: any;
-    }
+declare module '@react-three/fiber' {
+  interface ThreeElements {
+    tVStaticShaderMaterial: Object3DNode<
+      TVStaticShaderMaterial,
+      typeof TVStaticShaderMaterial
+    >;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove unused imports from roadmap and 3D background components
- type custom shader material via `Object3DNode` to avoid any/namespace lint errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fb09b67108321ba8d9dd671d09ae0