### PR TITLE
Normalize email input before waitlist submission

### DIFF
--- a/src/services/waitlistService.test.ts
+++ b/src/services/waitlistService.test.ts
@@ -52,4 +52,16 @@ describe('addEmailToWaitlist', () => {
     expect(result.message).toBe('Please enter a valid email address.');
     expect(from).not.toHaveBeenCalled();
   });
+
+  it('normalizes email before submission', async () => {
+    maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    single.mockResolvedValueOnce({ data: { email: 'trim@example.com' }, error: null });
+
+    await addEmailToWaitlist('  Trim@Example.com  ');
+
+    expect(eq).toHaveBeenCalledWith('email', 'trim@example.com');
+    expect(insert).toHaveBeenCalledWith([
+      { email: 'trim@example.com', source: 'website' }
+    ]);
+  });
 });

--- a/src/services/waitlistService.ts
+++ b/src/services/waitlistService.ts
@@ -25,12 +25,15 @@ export interface WaitlistResponse {
  * Add an email to the waitlist
  */
 export async function addEmailToWaitlist(
-  email: string, 
+  email: string,
   source: string = 'website'
 ): Promise<WaitlistResponse> {
   try {
+    // Normalize email by trimming whitespace and lowercasing
+    const normalizedEmail = email.trim().toLowerCase();
+
     // Validate email format
-    if (!isValidEmail(email)) {
+    if (!isValidEmail(normalizedEmail)) {
       return {
         success: false,
         message: 'Please enter a valid email address.'
@@ -41,7 +44,7 @@ export async function addEmailToWaitlist(
     const { data: existingEntry, error: checkError } = await supabase
       .from('waitlist')
       .select('email')
-      .eq('email', email.toLowerCase())
+      .eq('email', normalizedEmail)
       .maybeSingle();
 
     if (checkError && checkError.code !== 'PGRST116') {
@@ -64,7 +67,7 @@ export async function addEmailToWaitlist(
       .from('waitlist')
       .insert([
         {
-          email: email.toLowerCase(),
+          email: normalizedEmail,
           source: source
         }
       ])


### PR DESCRIPTION
## Summary
- trim and lowercase emails before validating or storing in the waitlist
- add regression test covering whitespace and casing issues

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb71aa3448321a215051c2a5fe361