### PR TITLE
Fix lint issues and update types

### DIFF
--- a/src/components/RoadmapCard/RoadmapCard.tsx
+++ b/src/components/RoadmapCard/RoadmapCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { PhaseItem } from '../PhaseItem/PhaseItem';
 import styles from './RoadmapCard.module.scss';
 

--- a/src/components/ThreeDBackground/ThreeDBackground.tsx
+++ b/src/components/ThreeDBackground/ThreeDBackground.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useMemo } from 'react';
-import { Canvas, useFrame, useThree, extend } from '@react-three/fiber';
+import React, { useRef } from 'react';
+import { Canvas, useFrame, useThree, extend, Object3DNode } from '@react-three/fiber';
 import * as THREE from 'three';
 import styles from './ThreeDBackground.module.scss';
 
@@ -131,9 +131,13 @@ extend({ TVStaticShaderMaterial });
 
 // Declare the extended material for TypeScript
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      tVStaticShaderMaterial: any;
+      tVStaticShaderMaterial: Object3DNode<
+        TVStaticShaderMaterial,
+        typeof TVStaticShaderMaterial
+      >;
     }
   }
 }

--- a/src/services/waitlistService.test.ts
+++ b/src/services/waitlistService.test.ts
@@ -17,7 +17,7 @@ const insert = vi.fn(() => ({ select: selectAfterInsert }));
 const from = vi.fn(() => ({ select, insert }));
 
 // Attach the mocked `from` method to the Supabase client
-(supabase as any).from = from;
+(supabase as unknown as { from: typeof from }).from = from;
 
 describe('addEmailToWaitlist', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- remove unused imports in RoadmapCard and ThreeDBackground
- type custom shader material and avoid any casts
- replace any with typed assignment in waitlist service test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fbd8442b0832186e3e1ad57411c8a