### PR TITLE
test: verify theme hook reacts to system changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ The project exposes reusable React hooks for common browser preferences:
 - `usePrefersReducedMotion` reflects the user's reduced-motion setting so components can adapt animations.
 
 Use these hooks instead of accessing `matchMedia` or `localStorage` directly to keep behavior consistent across the app.
+
+```tsx
+import usePrefersReducedMotion from './hooks/usePrefersReducedMotion';
+import useTheme from './hooks/useTheme';
+
+const prefersReducedMotion = usePrefersReducedMotion();
+const { theme, toggleTheme } = useTheme();
+```
+
+They automatically respond to system setting changes and persist user choices, so include them wherever components need to know about theme or motion preferences.
+

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -34,6 +34,29 @@ describe('useTheme', () => {
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 
+  it('responds to system preference changes without saved theme', () => {
+    let listener: ((e: MediaQueryListEvent) => void) | null = null;
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn((_, cb) => {
+        listener = cb;
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('light');
+
+    act(() => {
+      listener?.({ matches: true } as MediaQueryListEvent);
+    });
+
+    expect(result.current.theme).toBe('dark');
+  });
+
   it('toggles theme and persists preference', () => {
     window.matchMedia = setupMatchMedia(false);
     const { result } = renderHook(() => useTheme());


### PR DESCRIPTION
## Summary
- document reusable `useTheme` and `usePrefersReducedMotion` hooks
- add unit test ensuring `useTheme` updates when system theme changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe642ac94832190c572eca5ad7708