### PR TITLE
feat: support aria labels for header logo

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { axe } from 'vitest-axe';
+import { toHaveNoViolations } from 'vitest-axe/matchers';
+import { Header } from './Header';
+
+expect.extend({ toHaveNoViolations });
+
+describe('Header', () => {
+  it('renders an accessible logo', async () => {
+    const { container, getByRole } = render(
+      <Header isLoaded={true} theme="light" onToggleTheme={() => {}} />
+    );
+
+    getByRole('img', { name: 'NorthLab' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Summary
- add optional `ariaLabel` to `NorthLabLockup` and expose it on the SVG for accessibility
- supply `ariaLabel` in `Header` and add tests verifying the logo is announced

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe7bfa5f48321810a53d44a24e004