### PR TITLE
Add WaitlistForm error-handling tests

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -3,10 +3,13 @@
  */
 import React from 'react';
 import { render } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 import { toHaveNoViolations } from 'vitest-axe/matchers';
 import { Header } from './Header';
+
+// jsdom does not implement canvas; mock to avoid errors in axe contrast checks
+HTMLCanvasElement.prototype.getContext = vi.fn();
 
 expect.extend({ toHaveNoViolations });
 

--- a/src/components/WaitlistForm/WaitlistForm.tsx
+++ b/src/components/WaitlistForm/WaitlistForm.tsx
@@ -1,11 +1,19 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { addEmailToWaitlist, supabase } from '../../services/waitlistService';
 import styles from './WaitlistForm.module.scss';
 
+/**
+ * Waitlist signup form.
+ *
+ * Validates the email locally, surfaces server responses and gracefully
+ * handles network errors by resetting the loading state and refocusing the
+ * input for correction.
+ */
 export const WaitlistForm: React.FC = () => {
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [msg, setMsg] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -13,12 +21,14 @@ export const WaitlistForm: React.FC = () => {
     if (!email.trim()) {
       setStatus("error");
       setMsg("Please enter your email address.");
+      inputRef.current?.focus();
       return;
     }
 
     if (!supabase) {
       setStatus("error");
       setMsg("Waitlist signups are currently unavailable. Please try again later.");
+      inputRef.current?.focus();
       return;
     }
 
@@ -36,11 +46,13 @@ export const WaitlistForm: React.FC = () => {
       } else {
         setStatus("error");
         setMsg(result.message);
+        inputRef.current?.focus();
       }
     } catch (error) {
       console.error('Form submission error:', error);
       setStatus("error");
       setMsg("Something went wrong. Please try again.");
+      inputRef.current?.focus();
     }
   }
 
@@ -50,6 +62,7 @@ export const WaitlistForm: React.FC = () => {
         <div className={styles.inputWrapper}>
           <label htmlFor="email" className="sr-only">Email address</label>
           <input
+            ref={inputRef}
             id="email"
             type="email"
             value={email}

--- a/src/components/WaitlistForm/__tests__/WaitlistForm.test.tsx
+++ b/src/components/WaitlistForm/__tests__/WaitlistForm.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WaitlistForm } from '../WaitlistForm';
+
+vi.mock('../../../services/waitlistService', () => ({
+  addEmailToWaitlist: vi.fn(),
+  supabase: {}
+}));
+import { addEmailToWaitlist } from '../../../services/waitlistService';
+
+describe('WaitlistForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('handles successful submission', async () => {
+    addEmailToWaitlist.mockResolvedValueOnce({ success: true, message: 'Success!' });
+
+    render(<WaitlistForm />);
+
+    const input = screen.getByLabelText('Email address');
+    const button = screen.getByRole('button');
+
+    fireEvent.change(input, { target: { value: 'test@example.com' } });
+    fireEvent.click(button);
+
+    await screen.findByText('Success!');
+    expect(addEmailToWaitlist).toHaveBeenCalledWith('test@example.com', 'website');
+    expect((input as HTMLInputElement).value).toBe('');
+  });
+
+  it('shows server error message', async () => {
+    addEmailToWaitlist.mockResolvedValueOnce({ success: false, message: 'Server error' });
+
+    render(<WaitlistForm />);
+
+    const input = screen.getByLabelText('Email address');
+    fireEvent.change(input, { target: { value: 'test@example.com' } });
+    fireEvent.click(screen.getByRole('button'));
+
+    await screen.findByText('Server error');
+    expect(addEmailToWaitlist).toHaveBeenCalled();
+  });
+
+  it('validates empty email', async () => {
+    render(<WaitlistForm />);
+
+    const input = screen.getByLabelText('Email address');
+    const form = input.closest('form')!;
+    fireEvent.submit(form);
+
+    await screen.findByText('Please enter your email address.');
+    expect(addEmailToWaitlist).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('focuses input and enables button on network error', async () => {
+    addEmailToWaitlist.mockRejectedValueOnce(new Error('network'));
+
+    render(<WaitlistForm />);
+
+    const input = screen.getByLabelText('Email address');
+    const button = screen.getByRole('button');
+
+    fireEvent.change(input, { target: { value: 'test@example.com' } });
+    fireEvent.click(button);
+
+    await screen.findByText('Something went wrong. Please try again.');
+    expect(button.hasAttribute('disabled')).toBe(false);
+    expect(document.activeElement).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive component tests for WaitlistForm success, server error, validation and network failure flows
- document and implement error-handling in WaitlistForm with input ref focus on failures
- mock canvas in Header test to avoid jsdom getContext errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe9c7adf8832196ab7063a87cc9a6