### PR TITLE
Reset waitlist feedback when email changes

### DIFF
--- a/src/components/WaitlistForm/WaitlistForm.tsx
+++ b/src/components/WaitlistForm/WaitlistForm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { addEmailToWaitlist, supabase } from '../../services/waitlistService';
 import styles from './WaitlistForm.module.scss';
 
@@ -14,6 +14,16 @@ export const WaitlistForm: React.FC = () => {
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [msg, setMsg] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const skipResetRef = useRef(false);
+
+  useEffect(() => {
+    if (skipResetRef.current) {
+      skipResetRef.current = false;
+      return;
+    }
+    setStatus("idle");
+    setMsg("");
+  }, [email]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -42,6 +52,7 @@ export const WaitlistForm: React.FC = () => {
       if (result.success) {
         setStatus("success");
         setMsg(result.message);
+        skipResetRef.current = true;
         setEmail("");
       } else {
         setStatus("error");

--- a/src/components/WaitlistForm/__tests__/WaitlistForm.test.tsx
+++ b/src/components/WaitlistForm/__tests__/WaitlistForm.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WaitlistForm } from '../WaitlistForm';
 
@@ -75,5 +75,23 @@ describe('WaitlistForm', () => {
     await screen.findByText('Something went wrong. Please try again.');
     expect(button.hasAttribute('disabled')).toBe(false);
     expect(document.activeElement).toBe(input);
+  });
+
+  it('clears feedback when email changes', async () => {
+    addEmailToWaitlist.mockResolvedValueOnce({ success: false, message: 'Server error' });
+
+    render(<WaitlistForm />);
+
+    const input = screen.getByLabelText('Email address');
+    fireEvent.change(input, { target: { value: 'test@example.com' } });
+    fireEvent.click(screen.getByRole('button'));
+
+    await screen.findByText('Server error');
+
+    fireEvent.change(input, { target: { value: 'new@example.com' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Server error')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- reset form status and message when the email input changes so feedback only applies to the latest submission
- add test ensuring feedback clears on new input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fedcd6f6083219bb27eb0161615df