### PR TITLE
Respect reduced motion in 3D background

### DIFF
--- a/src/components/ThreeDBackground/ThreeDBackground.test.tsx
+++ b/src/components/ThreeDBackground/ThreeDBackground.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ThreeDBackground } from './ThreeDBackground';
+import styles from './ThreeDBackground.module.scss';
+
+describe('ThreeDBackground', () => {
+  it('omits canvas and shows gradient overlay when prefersReducedMotion is true', async () => {
+    // Mock WebGL support so the canvas would render if not for prefersReducedMotion
+    Object.defineProperty(window, 'WebGLRenderingContext', {
+      value: function () {},
+      writable: true,
+    });
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({});
+
+    const { container } = render(
+      <ThreeDBackground mouseX={0} mouseY={0} prefersReducedMotion />
+    );
+
+    // Ensure no canvas is rendered
+    await waitFor(() => {
+      expect(container.querySelector('canvas')).toBeNull();
+    });
+
+    const overlay = container.querySelector(`.${styles.overlay}`);
+    expect(overlay).not.toBeNull();
+    // The overlay element uses a CSS class that applies the gradient fallback
+    expect((overlay as HTMLElement).className).toContain(styles.overlay);
+  });
+});
+

--- a/src/components/ThreeDBackground/ThreeDBackground.tsx
+++ b/src/components/ThreeDBackground/ThreeDBackground.tsx
@@ -231,8 +231,8 @@ const Scene: React.FC<{
 
 /**
  * Animated TV static background. Renders a WebGL scene when possible and
- * falls back to a static CSS gradient when WebGL is unsupported or when the
- * `disable3D` prop is set.
+ * falls back to a static CSS gradient when WebGL is unsupported, when the
+ * `disable3D` prop is set, or when the user prefers reduced motion.
  */
 export const ThreeDBackground: React.FC<ThreeDBackgroundProps> = ({
   mouseX,
@@ -246,7 +246,8 @@ export const ThreeDBackground: React.FC<ThreeDBackgroundProps> = ({
     setWebglSupported(isWebGLAvailable());
   }, []);
 
-  const shouldRenderCanvas = webglSupported && !disable3D;
+  const shouldRenderCanvas =
+    webglSupported && !disable3D && !prefersReducedMotion;
 
   return (
     <div className={styles.backgroundContainer}>


### PR DESCRIPTION
## Summary
- Skip rendering WebGL canvas when users prefer reduced motion and update docs
- Add test verifying gradient fallback appears without the canvas

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fedcf4b488321816f2819db216aa6