### PR TITLE
Handle theme hook in non-browser environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "globals": "^15.9.0",
         "jsdom": "^26.1.0",
         "postcss-scss": "^4.0.9",
+        "react-test-renderer": "^18.3.1",
         "sass": "^1.90.0",
         "stylelint": "^16.23.1",
         "stylelint-declaration-strict-value": "^1.10.11",
@@ -5327,6 +5328,42 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-use-measure": {
       "version": "2.1.7",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "globals": "^15.9.0",
     "jsdom": "^26.1.0",
     "postcss-scss": "^4.0.9",
+    "react-test-renderer": "^18.3.1",
     "sass": "^1.90.0",
     "stylelint": "^16.23.1",
     "stylelint-declaration-strict-value": "^1.10.11",

--- a/src/hooks/useTheme.server.test.ts
+++ b/src/hooks/useTheme.server.test.ts
@@ -1,0 +1,28 @@
+/* @vitest-environment node */
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { describe, it, expect } from 'vitest';
+import useTheme from './useTheme';
+
+describe('useTheme in non-browser environment', () => {
+  it('defaults to light and toggles without browser APIs', () => {
+    let result: ReturnType<typeof useTheme>;
+
+    const TestComponent = () => {
+      result = useTheme();
+      return null;
+    };
+
+    act(() => {
+      create(React.createElement(TestComponent));
+    });
+
+    expect(result!.theme).toBe('light');
+
+    act(() => {
+      result!.toggleTheme();
+    });
+
+    expect(result!.theme).toBe('dark');
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -6,24 +6,35 @@ const STORAGE_KEY = 'northlab-theme';
 
 export function useTheme() {
   const getInitialTheme = (): Theme => {
-    const saved = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    if (saved) {
-      return saved;
+    if (typeof window !== 'undefined') {
+      const saved = window.localStorage?.getItem(STORAGE_KEY) as Theme | null;
+      if (saved) {
+        return saved;
+      }
+      const prefersDark = window
+        .matchMedia?.('(prefers-color-scheme: dark)')
+        ?.matches;
+      if (prefersDark !== undefined) {
+        return prefersDark ? 'dark' : 'light';
+      }
     }
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    return prefersDark ? 'dark' : 'light';
+    return 'light';
   };
 
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
+    if (typeof window !== 'undefined') {
+      window.document.documentElement.setAttribute('data-theme', theme);
+    }
   }, [theme]);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    if (typeof window === 'undefined') return;
+    const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+    if (!mediaQuery) return;
     const handler = (e: MediaQueryListEvent) => {
-      if (!localStorage.getItem(STORAGE_KEY)) {
+      if (!window.localStorage?.getItem(STORAGE_KEY)) {
         setTheme(e.matches ? 'dark' : 'light');
       }
     };
@@ -34,7 +45,9 @@ export function useTheme() {
   const toggleTheme = () => {
     const newTheme: Theme = theme === 'dark' ? 'light' : 'dark';
     setTheme(newTheme);
-    localStorage.setItem(STORAGE_KEY, newTheme);
+    if (typeof window !== 'undefined') {
+      window.localStorage?.setItem(STORAGE_KEY, newTheme);
+    }
   };
 
   return { theme, toggleTheme } as const;


### PR DESCRIPTION
## Summary
- safeguard `useTheme` hook by checking for `window` and `localStorage` before use
- default to light theme when browser APIs are absent
- add server-side tests confirming behavior without DOM

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fedcc76a48321838c43fe4107bb5c