### PR TITLE
Refine typography scale and move roadmap into its own section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ScrollTrigger } from "gsap/ScrollTrigger";
 import Lenis from "@studio-freight/lenis";
 import { Header } from "./components/Header/Header";
 import { HeroSection } from "./components/HeroSection/HeroSection";
+import { RoadmapSection } from "./components/RoadmapSection/RoadmapSection";
 import { AboutSection } from "./components/AboutSection/AboutSection";
 import { CommunitySection } from "./components/CommunitySection/CommunitySection";
 import { FAQSection } from "./components/FAQSection/FAQSection";
@@ -317,7 +318,7 @@ export default function NorthLabComingSoon() {
       
       <Header isLoaded={isLoaded} />
       
-      <HeroSection 
+      <HeroSection
         isLoaded={isLoaded}
         globalRotateX={globalRotateX}
         globalRotateY={globalRotateY}
@@ -325,6 +326,9 @@ export default function NorthLabComingSoon() {
         headlineRef={headlineRef}
         descriptionRef={descriptionRef}
         featuresRef={featuresRef}
+      />
+
+      <RoadmapSection
         roadmapRef={roadmapRef}
         phaseNowRef={phaseNowRef}
         phaseNextRef={phaseNextRef}

--- a/src/components/AboutSection/AboutSection.module.scss
+++ b/src/components/AboutSection/AboutSection.module.scss
@@ -18,7 +18,7 @@
 }
 
 .aboutTitle {
-  font-size: var(--font-size-5xl);
+  font-size: var(--font-size-3xl);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
@@ -31,7 +31,7 @@
   max-width: 100%;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-5xl);
+    font-size: var(--font-size-3xl);
   }
 }
 

--- a/src/components/CommunitySection/CommunitySection.module.scss
+++ b/src/components/CommunitySection/CommunitySection.module.scss
@@ -8,7 +8,7 @@
 }
 
 .communityTitle {
-  font-size: var(--font-size-5xl);
+  font-size: var(--font-size-3xl);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
@@ -23,7 +23,7 @@
   hyphens: auto;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-5xl);
+    font-size: var(--font-size-3xl);
   }
 }
 

--- a/src/components/FAQSection/FAQSection.module.scss
+++ b/src/components/FAQSection/FAQSection.module.scss
@@ -12,7 +12,7 @@
 }
 
 .faqTitle {
-  font-size: var(--font-size-4xl);
+  font-size: var(--font-size-2xl);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
@@ -24,7 +24,7 @@
   max-width: 100%;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-4xl);
+    font-size: var(--font-size-2xl);
   }
 }
 

--- a/src/components/HeroSection/HeroSection.module.scss
+++ b/src/components/HeroSection/HeroSection.module.scss
@@ -4,21 +4,8 @@
   min-height: 100vh;
   display: flex;
   align-items: center;
-}
-
-.heroGrid {
-  display: grid;
-  gap: var(--spacing-4);
-  align-items: center;
-  width: 100%;
-  max-width: 100%;
-  overflow: hidden;
-  
-  @media (min-width: $lg) {
-    grid-template-columns: 1fr 1fr;
-    gap: var(--spacing-6);
-    align-items: flex-start;
-  }
+  justify-content: center;
+  text-align: center;
 }
 
 .heroContent {
@@ -28,20 +15,17 @@
   transform: translateY(var(--spacing-3));
   overflow-wrap: break-word;
   word-wrap: break-word;
-  
+  max-width: var(--max-w-3xl);
+  margin: 0 auto;
+
   &.loaded {
     opacity: 1;
     transform: translateY(0);
   }
-  
-  @media (min-width: $lg) {
-    grid-column: 1;
-    padding-right: var(--spacing-1-5);
-  }
 }
 
 .headline {
-  font-size: var(--font-size-7xl);
+  font-size: var(--font-size-4xl);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-tighter);
   line-height: var(--line-height-tight);
@@ -59,15 +43,7 @@
   -webkit-background-clip: text;
   color: transparent;
   animation: gradientMove 8s ease-in-out infinite;
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-7xl);
-  }
-  
-  @media (min-width: $lg) {
-    font-size: var(--font-size-7xl);
-  }
-  
+
   .word {
     display: inline-block;
   }
@@ -95,26 +71,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);
+  align-items: center;
   transition: transform 0.2s ease-out;
   will-change: transform;
   transform-style: preserve-3d;
-}
-
-.roadmapContainer {
-  transition: all 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.2s;
-  opacity: 0;
-  transform: translateY(var(--spacing-2));
-  width: 100%;
-  max-width: 100%;
-  overflow: hidden;
-  min-width: 0;
-  
-  &.loaded {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  
-  @media (min-width: $lg) {
-    grid-column: 2;
-  }
 }

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Container } from '../Container/Container';
 import { FeatureItem } from '../FeatureItem/FeatureItem';
 import { WaitlistForm } from '../WaitlistForm/WaitlistForm';
-import { RoadmapCard } from '../RoadmapCard/RoadmapCard';
 import { heroContent } from '../../data/content';
 import styles from './HeroSection.module.scss';
 
@@ -14,10 +13,6 @@ interface HeroSectionProps {
   headlineRef: React.RefObject<HTMLHeadingElement>;
   descriptionRef: React.RefObject<HTMLParagraphElement>;
   featuresRef: React.RefObject<HTMLDivElement>;
-  roadmapRef: React.RefObject<HTMLDivElement>;
-  phaseNowRef: React.RefObject<HTMLDivElement>;
-  phaseNextRef: React.RefObject<HTMLDivElement>;
-  phaseLaterRef: React.RefObject<HTMLDivElement>;
 }
 
 export const HeroSection: React.FC<HeroSectionProps> = ({
@@ -27,18 +22,13 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
   heroRef,
   headlineRef,
   descriptionRef,
-  featuresRef,
-  roadmapRef,
-  phaseNowRef,
-  phaseNextRef,
-  phaseLaterRef
+  featuresRef
 }) => {
   return (
     <section ref={heroRef} className={styles.hero}>
       <Container>
-        <div className={styles.heroGrid}>
-          <div className={`${styles.heroContent} ${isLoaded ? styles.loaded : ''}`}>
-            <h1 
+        <div className={`${styles.heroContent} ${isLoaded ? styles.loaded : ''}`}>
+            <h1
               ref={headlineRef}
               className={styles.headline}
               style={{
@@ -75,17 +65,6 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
             </div>
 
             <WaitlistForm />
-          </div>
-
-          <div className={`${styles.roadmapContainer} ${isLoaded ? styles.loaded : ''}`}>
-            <div ref={roadmapRef}>
-              <RoadmapCard 
-                phaseNowRef={phaseNowRef}
-                phaseNextRef={phaseNextRef}
-                phaseLaterRef={phaseLaterRef}
-              />
-            </div>
-          </div>
         </div>
       </Container>
     </section>

--- a/src/components/RoadmapSection/RoadmapSection.module.scss
+++ b/src/components/RoadmapSection/RoadmapSection.module.scss
@@ -1,0 +1,13 @@
+.roadmap {
+  border-top: var(--border-width-sm) solid var(--color-border-primary);
+  padding-top: var(--spacing-6);
+  padding-bottom: var(--spacing-8);
+  display: flex;
+  justify-content: center;
+}
+
+.cardWrapper {
+  width: 100%;
+  max-width: var(--max-w-3xl);
+  margin: 0 auto;
+}

--- a/src/components/RoadmapSection/RoadmapSection.tsx
+++ b/src/components/RoadmapSection/RoadmapSection.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Container } from '../Container/Container';
+import { RoadmapCard } from '../RoadmapCard/RoadmapCard';
+import styles from './RoadmapSection.module.scss';
+
+interface RoadmapSectionProps {
+  roadmapRef: React.RefObject<HTMLDivElement>;
+  phaseNowRef: React.RefObject<HTMLDivElement>;
+  phaseNextRef: React.RefObject<HTMLDivElement>;
+  phaseLaterRef: React.RefObject<HTMLDivElement>;
+}
+
+export const RoadmapSection: React.FC<RoadmapSectionProps> = ({
+  roadmapRef,
+  phaseNowRef,
+  phaseNextRef,
+  phaseLaterRef
+}) => (
+  <section className={styles.roadmap} ref={roadmapRef}>
+    <Container>
+      <div className={styles.cardWrapper}>
+        <RoadmapCard
+          phaseNowRef={phaseNowRef}
+          phaseNextRef={phaseNextRef}
+          phaseLaterRef={phaseLaterRef}
+        />
+      </div>
+    </Container>
+  </section>
+);

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -80,10 +80,7 @@
   --font-size-xl: clamp(1.25rem, 1.2rem + 0.25vw, 1.5rem);       // 20px-24px
   --font-size-2xl: clamp(1.5rem, 1.4rem + 0.5vw, 2rem);          // 24px-32px
   --font-size-3xl: clamp(1.875rem, 1.75rem + 0.625vw, 2.5rem);   // 30px-40px
-  --font-size-4xl: clamp(2.25rem, 2rem + 1.25vw, 3.5rem);        // 36px-56px
-  --font-size-5xl: clamp(3rem, 2.5rem + 2.5vw, 5rem);            // 48px-80px
-  --font-size-6xl: clamp(3.75rem, 3rem + 3.75vw, 6.25rem);       // 60px-100px
-  --font-size-7xl: clamp(3rem, 2.5rem + 2.5vw, 4.5rem);          // 48px-72px
+  --font-size-4xl: clamp(3rem, 2.5rem + 2.5vw, 4.5rem);          // 48px-72px
   
   // Line heights
   --line-height-none: 1;


### PR DESCRIPTION
## Summary
- simplify typography scale and update section titles for leaner styles
- center hero content and drop floating roadmap card
- add dedicated roadmap section below the hero

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff8ed3d348321b4940373320eb477