### PR TITLE
Refactor typography and add parallax background

### DIFF
--- a/public/parallax-bg.svg
+++ b/public/parallax-bg.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff00ea" />
+      <stop offset="100%" stop-color="#4100f5" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="#000" />
+  <path d="M-100 200 Q300 0 600 200 T1300 200" stroke="url(#grad1)" stroke-width="200" fill="none" />
+  <path d="M-100 600 Q300 800 600 600 T1300 600" stroke="url(#grad1)" stroke-width="200" fill="none" opacity="0.6" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { CommunitySection } from "./components/CommunitySection/CommunitySection
 import { FAQSection } from "./components/FAQSection/FAQSection";
 import { Footer } from "./components/Footer/Footer";
 import { ThreeDBackground } from "./components/ThreeDBackground/ThreeDBackground";
+import { ParallaxBackground } from "./components/ParallaxBackground/ParallaxBackground";
 import "./styles/globals.scss";
 import usePrefersReducedMotion from "./hooks/usePrefersReducedMotion";
 
@@ -310,6 +311,7 @@ export default function NorthLabComingSoon() {
       onMouseMove={handleGlobalMouseMove}
       onMouseLeave={handleGlobalMouseLeave}
     >
+      <ParallaxBackground />
       <ThreeDBackground
         mouseX={mousePosition.x}
         mouseY={mousePosition.y}

--- a/src/components/AboutSection/AboutSection.module.scss
+++ b/src/components/AboutSection/AboutSection.module.scss
@@ -18,26 +18,16 @@
 }
 
 .aboutTitle {
-  font-size: var(--font-size-3xl);
-  font-weight: 700;
-  letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
   margin-bottom: var(--spacing-2-5);
   text-wrap: balance;
-  line-height: var(--line-height-tight);
   overflow-wrap: break-word;
   word-wrap: break-word;
   hyphens: auto;
   max-width: 100%;
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-3xl);
-  }
 }
 
 .aboutDescription {
-  font-size: var(--font-size-lg);
-  line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
   max-width: 65ch;
   margin-left: auto;
@@ -45,15 +35,9 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   margin-bottom: var(--spacing-1-5);
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-xl);
-  }
 }
 
 .aboutDescriptionFinal {
-  font-size: var(--font-size-lg);
-  line-height: var(--line-height-relaxed);
   color: var(--color-text-tertiary);
   max-width: 65ch;
   margin-left: auto;
@@ -61,10 +45,6 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   font-weight: 500;
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-xl);
-  }
 }
 
 .aboutBenefits {
@@ -144,20 +124,14 @@
 }
 
 .benefitTitle {
-  font-size: var(--font-size-lg);
-  font-weight: 700;
-  letter-spacing: var(--letter-spacing-wide);
   color: var(--color-text-primary);
   margin-bottom: var(--spacing-1-5);
-  text-transform: uppercase;
   overflow-wrap: break-word;
   word-wrap: break-word;
   flex-shrink: 0;
 }
 
 .benefitDescription {
-  font-size: var(--font-size-base);
-  line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/src/components/AboutSection/AboutSection.tsx
+++ b/src/components/AboutSection/AboutSection.tsx
@@ -25,16 +25,16 @@ export const AboutSection: React.FC<AboutSectionProps> = ({ aboutRef }) => {
     <section ref={aboutRef} id="about" className={styles.about}>
       <Container>
         <div className={styles.aboutContent}>
-          <h2 className={`${styles.aboutTitle} animate-element`}>
+          <h2 className={`${styles.aboutTitle} typography-h2 animate-element`}>
             You've been building in the wild
           </h2>
-          <p className={`${styles.aboutDescription} animate-element`}>
+          <p className={`${styles.aboutDescription} typography-body-lg animate-element`}>
             If you're a freelancer or creator, you know the grind isn't just the work. It's finding direction, the right opportunities, and the people who truly get what you do.
           </p>
-          <p className={`${styles.aboutDescription} animate-element`}>
+          <p className={`${styles.aboutDescription} typography-body-lg animate-element`}>
             NorthLab exists to make that part effortless. We're building a platform that's both your creative workspace and your source of direction, helping you test ideas, get trusted feedback, and see your next move before it's obvious.
           </p>
-          <p className={`${styles.aboutDescriptionFinal} animate-element`}>
+          <p className={`${styles.aboutDescriptionFinal} typography-body-lg animate-element`}>
             All in one place, designed for people who want more control over their creative journey.
           </p>
         </div>
@@ -45,8 +45,8 @@ export const AboutSection: React.FC<AboutSectionProps> = ({ aboutRef }) => {
               <div className={styles.benefitIcon}>
                 {getIcon(benefit.icon)}
               </div>
-              <h3 className={styles.benefitTitle}>{benefit.title}</h3>
-              <p className={styles.benefitDescription}>{benefit.description}</p>
+              <h3 className={`${styles.benefitTitle} typography-label`}>{benefit.title}</h3>
+              <p className={`${styles.benefitDescription} typography-body`}>{benefit.description}</p>
               <div className={styles.benefitArrow}>
                 <ArrowUpRight size={20} />
               </div>

--- a/src/components/CommunitySection/CommunitySection.module.scss
+++ b/src/components/CommunitySection/CommunitySection.module.scss
@@ -8,36 +8,22 @@
 }
 
 .communityTitle {
-  font-size: var(--font-size-3xl);
-  font-weight: 700;
-  letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
   margin-bottom: var(--spacing-2-5);
   text-wrap: balance;
-  line-height: var(--line-height-tight);
   max-width: var(--max-w-4xl);
   margin-left: auto;
   margin-right: auto;
   overflow-wrap: break-word;
   word-wrap: break-word;
   hyphens: auto;
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-3xl);
-  }
 }
 
 .communityDescription {
-  font-size: var(--font-size-lg);
-  line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
   max-width: var(--max-w-2xl);
   margin-left: auto;
   margin-right: auto;
   overflow-wrap: break-word;
   word-wrap: break-word;
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-xl);
-  }
 }

--- a/src/components/CommunitySection/CommunitySection.tsx
+++ b/src/components/CommunitySection/CommunitySection.tsx
@@ -10,10 +10,10 @@ export const CommunitySection: React.FC<CommunitySectionProps> = ({ communityRef
   return (
     <section ref={communityRef} id="community" className={styles.community}>
       <Container>
-        <h2 className={`${styles.communityTitle} animate-element`}>
+        <h2 className={`${styles.communityTitle} typography-h2 animate-element`}>
           This isn't just a launch. It's a starting line.
         </h2>
-        <p className={`${styles.communityDescription} animate-element`}>
+        <p className={`${styles.communityDescription} typography-body-lg animate-element`}>
           Join now and help shape what NorthLab becomes. Early members will get first access, behind-the-scenes updates, and the chance to co-create features that make a difference for real working creators.
         </p>
       </Container>

--- a/src/components/FAQSection/FAQSection.module.scss
+++ b/src/components/FAQSection/FAQSection.module.scss
@@ -12,34 +12,20 @@
 }
 
 .faqTitle {
-  font-size: var(--font-size-2xl);
-  font-weight: 700;
-  letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
   margin-bottom: var(--spacing-2);
-  line-height: var(--line-height-tight);
   overflow-wrap: break-word;
   word-wrap: break-word;
   text-wrap: balance;
   max-width: 100%;
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-2xl);
-  }
 }
 
 .faqDescription {
-  font-size: var(--font-size-lg);
   color: var(--color-text-tertiary);
   max-width: var(--max-w-2xl);
   margin: 0 auto;
-  line-height: var(--line-height-relaxed);
   overflow-wrap: break-word;
   word-wrap: break-word;
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-xl);
-  }
 }
 
 .faqList {
@@ -92,20 +78,14 @@
 }
 
 .faqQuestion {
-  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--color-text-primary);
-  line-height: var(--line-height-relaxed);
   padding-right: var(--spacing-1);
   overflow-wrap: break-word;
   word-wrap: break-word;
   hyphens: auto;
   flex: 1;
   min-width: 0;
-  
-  @media (min-width: $sm) {
-    font-size: var(--font-size-lg);
-  }
 }
 
 .faqIcon {
@@ -132,12 +112,10 @@
 .faqAnswerContent {
   padding: 0 var(--spacing-2) var(--spacing-2) var(--spacing-2);
   color: var(--color-text-secondary);
-  font-size: var(--font-size-base);
-  line-height: var(--line-height-relaxed);
   overflow-wrap: break-word;
   word-wrap: break-word;
   max-width: 100%;
-  
+
   @media (min-width: $sm) {
     padding: 0 var(--spacing-2-5) var(--spacing-2-5) var(--spacing-2-5);
   }

--- a/src/components/FAQSection/FAQSection.tsx
+++ b/src/components/FAQSection/FAQSection.tsx
@@ -19,14 +19,14 @@ const FAQItem: React.FC<FAQItemProps> = ({ question, answer, isOpen, onToggle })
         onClick={onToggle}
         aria-expanded={isOpen}
       >
-        <span className={styles.faqQuestion}>{question}</span>
+        <span className={`${styles.faqQuestion} typography-body`}>{question}</span>
         <ChevronDown 
           className={`${styles.faqIcon} ${isOpen ? styles.rotated : ''}`}
           size={20}
         />
       </button>
       <div className={`${styles.faqAnswer} ${isOpen ? styles.expanded : ''}`}>
-        <div className={styles.faqAnswerContent}>
+        <div className={`${styles.faqAnswerContent} typography-body`}>
           {answer}
         </div>
       </div>
@@ -55,10 +55,10 @@ export const FAQSection: React.FC<FAQSectionProps> = ({ faqRef }) => {
     <section ref={faqRef} id="faq" className={styles.faq}>
       <Container size="narrow">
         <div className={styles.faqHeader}>
-          <h2 className={`${styles.faqTitle} animate-element`}>
+          <h2 className={`${styles.faqTitle} typography-h2 animate-element`}>
             First-ever asked questions from real users
           </h2>
-          <p className={`${styles.faqDescription} animate-element`}>
+          <p className={`${styles.faqDescription} typography-body-lg animate-element`}>
             The questions that matter most, answered directly.
           </p>
         </div>

--- a/src/components/FeatureItem/FeatureItem.module.scss
+++ b/src/components/FeatureItem/FeatureItem.module.scss
@@ -19,6 +19,4 @@
 
 .text {
   color: var(--color-text-secondary);
-  font-size: var(--font-size-lg);
-  line-height: var(--line-height-relaxed);
 }

--- a/src/components/FeatureItem/FeatureItem.tsx
+++ b/src/components/FeatureItem/FeatureItem.tsx
@@ -10,7 +10,7 @@ export const FeatureItem: React.FC<FeatureItemProps> = ({ children, className = 
   return (
     <div className={`${styles.featureItem} group feature-item ${className}`}>
       <div className={styles.dot} />
-      <span className={styles.text}>{children}</span>
+      <span className={`${styles.text} typography-body-lg`}>{children}</span>
     </div>
   );
 };

--- a/src/components/HeroSection/HeroSection.module.scss
+++ b/src/components/HeroSection/HeroSection.module.scss
@@ -25,10 +25,6 @@
 }
 
 .headline {
-  font-size: var(--font-size-4xl);
-  font-weight: 700;
-  letter-spacing: var(--letter-spacing-tighter);
-  line-height: var(--line-height-tight);
   transition: transform 0.2s ease-out;
   will-change: transform;
   transform-style: preserve-3d;
@@ -51,8 +47,6 @@
 
 .description {
   margin-top: var(--spacing-1);
-  font-size: var(--font-size-xl);
-  line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
   max-width: var(--max-w-2xl);
   transition: transform 0.2s ease-out;

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -30,7 +30,7 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
         <div className={`${styles.heroContent} ${isLoaded ? styles.loaded : ''}`}>
             <h1
               ref={headlineRef}
-              className={styles.headline}
+              className={`${styles.headline} typography-h1`}
               style={{
                 transform: `rotateX(${globalRotateX * -0.3}deg) rotateY(${globalRotateY * -0.3}deg) translateZ(20px)`,
               }}
@@ -38,9 +38,9 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
               The future of independent creators has a new North. Yours.
             </h1>
             
-            <p 
+            <p
               ref={descriptionRef}
-              className={styles.description}
+              className={`${styles.description} typography-body-lg`}
               style={{
                 transform: `rotateX(${globalRotateX * -0.2}deg) rotateY(${globalRotateY * -0.2}deg) translateZ(10px)`,
               }}

--- a/src/components/ParallaxBackground/ParallaxBackground.module.scss
+++ b/src/components/ParallaxBackground/ParallaxBackground.module.scss
@@ -1,0 +1,12 @@
+.parallaxBg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-image: url('/parallax-bg.svg');
+  background-size: cover;
+  background-position: center;
+  z-index: -5;
+  will-change: transform;
+}

--- a/src/components/ParallaxBackground/ParallaxBackground.tsx
+++ b/src/components/ParallaxBackground/ParallaxBackground.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useRef } from 'react';
+import styles from './ParallaxBackground.module.scss';
+
+export const ParallaxBackground: React.FC = () => {
+  const bgRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (bgRef.current) {
+        const offset = window.scrollY * 0.3;
+        bgRef.current.style.transform = `translateY(${offset}px)`;
+      }
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return <div ref={bgRef} className={styles.parallaxBg} />;
+};

--- a/src/components/PhaseItem/PhaseItem.module.scss
+++ b/src/components/PhaseItem/PhaseItem.module.scss
@@ -24,6 +24,4 @@
 }
 
 .text {
-  font-size: var(--font-size-base);
-  line-height: var(--line-height-relaxed);
 }

--- a/src/components/PhaseItem/PhaseItem.tsx
+++ b/src/components/PhaseItem/PhaseItem.tsx
@@ -10,7 +10,7 @@ export const PhaseItem: React.FC<PhaseItemProps> = ({ children, dotColor = 'indi
   return (
     <div className={`${styles.phaseItem} phase-item`}>
       <div className={`${styles.dot} ${styles[`dot${dotColor.charAt(0).toUpperCase() + dotColor.slice(1)}`]}`} />
-      <span className={styles.text}>{children}</span>
+      <span className={`${styles.text} typography-body`}>{children}</span>
     </div>
   );
 };

--- a/src/components/RoadmapCard/RoadmapCard.module.scss
+++ b/src/components/RoadmapCard/RoadmapCard.module.scss
@@ -71,11 +71,7 @@
 }
 
 .phaseTitle {
-  font-size: var(--font-size-sm);
-  text-transform: uppercase;
-  letter-spacing: var(--letter-spacing-wider);
   color: var(--color-text-tertiary);
-  font-weight: 500;
   margin-bottom: var(--spacing-0-75);
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/src/components/RoadmapCard/RoadmapCard.tsx
+++ b/src/components/RoadmapCard/RoadmapCard.tsx
@@ -75,7 +75,7 @@ export const RoadmapCard: React.FC<RoadmapCardProps> = ({
           }}
         >
           <div ref={phaseNowRef} className={styles.phase}>
-            <div className={styles.phaseTitle}>Now</div>
+            <div className={`${styles.phaseTitle} typography-overline`}>Now</div>
             <div className={styles.phaseItems}>
               <PhaseItem dotColor="indigo">
                 Closed alpha with core creative memory and brief engine
@@ -87,7 +87,7 @@ export const RoadmapCard: React.FC<RoadmapCardProps> = ({
           </div>
           
           <div ref={phaseNextRef} className={styles.phase}>
-            <div className={styles.phaseTitle}>Next</div>
+            <div className={`${styles.phaseTitle} typography-overline`}>Next</div>
             <div className={styles.phaseItems}>
               <PhaseItem dotColor="sky">
                 Bias resistant reviews and skill leveling
@@ -99,7 +99,7 @@ export const RoadmapCard: React.FC<RoadmapCardProps> = ({
           </div>
           
           <div ref={phaseLaterRef} className={styles.phase}>
-            <div className={styles.phaseTitle}>Later</div>
+            <div className={`${styles.phaseTitle} typography-overline`}>Later</div>
             <div className={`${styles.phaseItems} ${styles.phaseItemsLater}`}>
               <PhaseItem dotColor="neutral">
                 Marketplace with verified talent tiers

--- a/src/components/ThreeDBackground/ThreeDBackground.module.scss
+++ b/src/components/ThreeDBackground/ThreeDBackground.module.scss
@@ -22,9 +22,9 @@
   height: 100%;
   background: linear-gradient(
     135deg,
-    rgba(var(--color-neutral-950-rgb), 0.85) 0%,
-    rgba(var(--color-neutral-950-rgb), 0.80) 50%,
-    rgba(var(--color-neutral-950-rgb), 0.85) 100%
+    rgba(var(--color-neutral-950-rgb), 0.7) 0%,
+    rgba(var(--color-neutral-950-rgb), 0.65) 50%,
+    rgba(var(--color-neutral-950-rgb), 0.7) 100%
   );
   z-index: -3;
   pointer-events: none;

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -1,0 +1,45 @@
+// Typography utility classes
+.typography-h1 {
+  font-size: var(--font-size-4xl);
+  line-height: var(--line-height-tight);
+  font-weight: 700;
+  letter-spacing: var(--letter-spacing-tighter);
+}
+
+.typography-h2 {
+  font-size: var(--font-size-3xl);
+  line-height: var(--line-height-tight);
+  font-weight: 700;
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.typography-h3 {
+  font-size: var(--font-size-2xl);
+  line-height: var(--line-height-snug);
+  font-weight: 700;
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.typography-body-lg {
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-relaxed);
+}
+
+.typography-body {
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-relaxed);
+}
+
+.typography-label {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.typography-overline {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  letter-spacing: var(--letter-spacing-wider);
+  text-transform: uppercase;
+}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,5 +1,6 @@
 // Import SCSS partials
 @import 'variables';
+@import 'typography';
 @import 'mixins';
 
 // Global styles and CSS custom properties


### PR DESCRIPTION
## Summary
- introduce reusable typography utility classes and apply them across hero, about, community, FAQ and roadmap elements for consistent type hierarchy
- add scroll-tied parallax background using new SVG asset and integrate into app with lighter 3D overlay

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ffc42ee0c8321bc5a61ffad434733