### PR TITLE
refactor: adopt modular typography scale

### DIFF
--- a/src/components/AboutSection/AboutSection.module.scss
+++ b/src/components/AboutSection/AboutSection.module.scss
@@ -18,7 +18,7 @@
 }
 
 .aboutTitle {
-  font-size: var(--font-size-3xl);
+  font-size: var(--font-size-6);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
@@ -31,12 +31,12 @@
   max-width: 100%;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-3xl);
+    font-size: var(--font-size-6);
   }
 }
 
 .aboutDescription {
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-4);
   line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
   max-width: 65ch;
@@ -47,12 +47,12 @@
   margin-bottom: var(--spacing-1-5);
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-5);
   }
 }
 
 .aboutDescriptionFinal {
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-4);
   line-height: var(--line-height-relaxed);
   color: var(--color-text-tertiary);
   max-width: 65ch;
@@ -63,7 +63,7 @@
   font-weight: 500;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-5);
   }
 }
 
@@ -144,7 +144,7 @@
 }
 
 .benefitTitle {
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-4);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-wide);
   color: var(--color-text-primary);
@@ -156,7 +156,7 @@
 }
 
 .benefitDescription {
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-3);
   line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
   overflow-wrap: break-word;

--- a/src/components/CommunitySection/CommunitySection.module.scss
+++ b/src/components/CommunitySection/CommunitySection.module.scss
@@ -8,7 +8,7 @@
 }
 
 .communityTitle {
-  font-size: var(--font-size-3xl);
+  font-size: var(--font-size-6);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
@@ -23,12 +23,12 @@
   hyphens: auto;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-3xl);
+    font-size: var(--font-size-6);
   }
 }
 
 .communityDescription {
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-4);
   line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
   max-width: var(--max-w-2xl);
@@ -38,6 +38,6 @@
   word-wrap: break-word;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-5);
   }
 }

--- a/src/components/FAQSection/FAQSection.module.scss
+++ b/src/components/FAQSection/FAQSection.module.scss
@@ -12,7 +12,7 @@
 }
 
 .faqTitle {
-  font-size: var(--font-size-2xl);
+  font-size: var(--font-size-6);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
@@ -24,12 +24,12 @@
   max-width: 100%;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-2xl);
+    font-size: var(--font-size-6);
   }
 }
 
 .faqDescription {
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-4);
   color: var(--color-text-tertiary);
   max-width: var(--max-w-2xl);
   margin: 0 auto;
@@ -38,7 +38,7 @@
   word-wrap: break-word;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-5);
   }
 }
 
@@ -92,7 +92,7 @@
 }
 
 .faqQuestion {
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-3);
   font-weight: 500;
   color: var(--color-text-primary);
   line-height: var(--line-height-relaxed);
@@ -104,7 +104,7 @@
   min-width: 0;
   
   @media (min-width: $sm) {
-    font-size: var(--font-size-lg);
+    font-size: var(--font-size-4);
   }
 }
 
@@ -132,7 +132,7 @@
 .faqAnswerContent {
   padding: 0 var(--spacing-2) var(--spacing-2) var(--spacing-2);
   color: var(--color-text-secondary);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-3);
   line-height: var(--line-height-relaxed);
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/src/components/FeatureItem/FeatureItem.module.scss
+++ b/src/components/FeatureItem/FeatureItem.module.scss
@@ -19,6 +19,6 @@
 
 .text {
   color: var(--color-text-secondary);
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-4);
   line-height: var(--line-height-relaxed);
 }

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -23,7 +23,7 @@
 }
 
 .copyright {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-2);
   color: var(--color-text-tertiary);
   overflow-wrap: break-word;
   word-wrap: break-word;
@@ -35,7 +35,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-2);
   color: var(--color-text-tertiary);
   flex-wrap: wrap;
   flex-shrink: 0;

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -33,7 +33,7 @@
     display: flex;
     align-items: center;
     gap: var(--spacing-2);
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-2);
     font-weight: 500;
     color: var(--color-text-secondary);
     margin-left: auto;

--- a/src/components/HeroSection/HeroSection.module.scss
+++ b/src/components/HeroSection/HeroSection.module.scss
@@ -25,7 +25,7 @@
 }
 
 .headline {
-  font-size: var(--font-size-4xl);
+  font-size: var(--font-size-6);
   font-weight: 700;
   letter-spacing: var(--letter-spacing-tighter);
   line-height: var(--line-height-tight);
@@ -51,7 +51,7 @@
 
 .description {
   margin-top: var(--spacing-1);
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-5);
   line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
   max-width: var(--max-w-2xl);

--- a/src/components/PhaseItem/PhaseItem.module.scss
+++ b/src/components/PhaseItem/PhaseItem.module.scss
@@ -24,6 +24,6 @@
 }
 
 .text {
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-3);
   line-height: var(--line-height-relaxed);
 }

--- a/src/components/RoadmapCard/RoadmapCard.module.scss
+++ b/src/components/RoadmapCard/RoadmapCard.module.scss
@@ -71,7 +71,7 @@
 }
 
 .phaseTitle {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-2);
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-wider);
   color: var(--color-text-tertiary);

--- a/src/components/WaitlistForm/WaitlistForm.module.scss
+++ b/src/components/WaitlistForm/WaitlistForm.module.scss
@@ -36,7 +36,7 @@
   color: var(--color-text-primary);
   outline: none;
   transition: all 0.2s ease-out;
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-3);
   box-sizing: border-box;
   overflow-wrap: break-word;
   word-wrap: break-word;
@@ -68,7 +68,7 @@
   transition: all 0.2s ease-out;
   border: none;
   cursor: pointer;
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-3);
   white-space: nowrap;
   flex-shrink: 0;
   min-width: fit-content;
@@ -109,7 +109,7 @@
 
 .message {
   margin-top: var(--spacing-1-5);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-2);
   font-weight: 500;
   transition: all 0.3s ease-out;
   
@@ -124,7 +124,7 @@
 
 .disclaimer {
   margin-top: var(--spacing-2);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-2);
   color: var(--color-text-tertiary);
   line-height: var(--line-height-relaxed);
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -72,15 +72,13 @@
   --spacing-6: clamp(5rem, 4rem + 5vw, 8rem);              // 80px-128px
   --spacing-8: clamp(6rem, 5rem + 5vw, 10rem);             // 96px-160px
   
-  // Typography scale
-  --font-size-xs: 0.75rem;                                    // 12px
-  --font-size-sm: clamp(0.875rem, 0.85rem + 0.125vw, 0.9375rem); // 14px-15px
-  --font-size-base: 1rem;                                         // 16px
-  --font-size-lg: clamp(1.125rem, 1.1rem + 0.125vw, 1.25rem);    // 18px-20px
-  --font-size-xl: clamp(1.25rem, 1.2rem + 0.25vw, 1.5rem);       // 20px-24px
-  --font-size-2xl: clamp(1.5rem, 1.4rem + 0.5vw, 2rem);          // 24px-32px
-  --font-size-3xl: clamp(1.875rem, 1.75rem + 0.625vw, 2.5rem);   // 30px-40px
-  --font-size-4xl: clamp(3rem, 2.5rem + 2.5vw, 4.5rem);          // 48px-72px
+  // Typography scale (modular 1.25 ratio, 12px base)
+  --font-size-1: 0.75rem;    // 12px
+  --font-size-2: 0.9375rem;  // 15px
+  --font-size-3: 1.1719rem;  // 18.75px
+  --font-size-4: 1.4648rem;  // 23.44px
+  --font-size-5: 1.8311rem;  // 29.30px
+  --font-size-6: 2.2889rem;  // 36.62px
   
   // Line heights
   --line-height-none: 1;
@@ -181,7 +179,7 @@ body {
   color: var(--color-text-primary);
   overflow-x: hidden;
   line-height: var(--line-height-normal);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-3);
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- replace font size tokens with 1.25 modular scale
- update components to use new font size variables

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a002ddd66c8321ac6b794c18f06694