### PR TITLE
Adjust header logo size and navigation spacing

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -18,7 +18,7 @@
 }
 
 .logo {
-  height: clamp(var(--spacing-1-5), 1.2rem + 1.5vw, var(--spacing-2));
+  height: clamp(1.25rem, 0.9rem + 1.5vw, 1.5rem);
   width: auto;
   color: var(--color-neutral-50);
   max-width: 100%;
@@ -32,11 +32,12 @@
   @media (min-width: $sm) {
     display: flex;
     align-items: center;
-    gap: var(--spacing-2);
+    gap: var(--spacing-1-5);
     font-size: var(--font-size-2);
     font-weight: 500;
     color: var(--color-text-secondary);
     margin-left: auto;
+    padding-block: var(--spacing-0-5);
     flex-wrap: wrap;
     overflow-wrap: break-word;
     word-wrap: break-word;


### PR DESCRIPTION
## Summary
- reduce header logo height clamp for tighter 20–24px range
- refine desktop navigation spacing and add vertical padding for alignment

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a00521ba3c8321bcf99262ece924ea