### PR TITLE
refactor section spacing for smoother rhythm

### DIFF
--- a/src/components/AboutSection/AboutSection.module.scss
+++ b/src/components/AboutSection/AboutSection.module.scss
@@ -2,8 +2,8 @@
   border-top: var(--border-width-sm) solid var(--color-border-primary);
   position: relative;
   z-index: var(--z-0);
-  padding-top: var(--spacing-6);
-  padding-bottom: var(--spacing-8);
+  padding-top: var(--spacing-4);
+  padding-bottom: var(--spacing-5);
 }
 
 .aboutContent {

--- a/src/components/CommunitySection/CommunitySection.module.scss
+++ b/src/components/CommunitySection/CommunitySection.module.scss
@@ -2,8 +2,8 @@
   border-top: var(--border-width-sm) solid var(--color-border-primary);
   position: relative;
   z-index: var(--z-0);
-  padding-top: var(--spacing-6);
-  padding-bottom: var(--spacing-8);
+  padding-top: var(--spacing-4);
+  padding-bottom: var(--spacing-5);
   text-align: center;
 }
 

--- a/src/components/FAQSection/FAQSection.module.scss
+++ b/src/components/FAQSection/FAQSection.module.scss
@@ -2,8 +2,8 @@
   border-top: var(--border-width-sm) solid var(--color-border-primary);
   position: relative;
   z-index: var(--z-0);
-  padding-top: var(--spacing-6);
-  padding-bottom: var(--spacing-8);
+  padding-top: var(--spacing-4);
+  padding-bottom: var(--spacing-5);
 }
 
 .faqHeader {

--- a/src/components/HeroSection/HeroSection.module.scss
+++ b/src/components/HeroSection/HeroSection.module.scss
@@ -1,6 +1,6 @@
 .hero {
-  padding-top: var(--spacing-3);
-  padding-bottom: var(--spacing-8);
+  padding-top: var(--spacing-4);
+  padding-bottom: var(--spacing-5);
   min-height: 100vh;
   display: flex;
   align-items: center;

--- a/src/components/RoadmapSection/RoadmapSection.module.scss
+++ b/src/components/RoadmapSection/RoadmapSection.module.scss
@@ -1,7 +1,7 @@
 .roadmap {
   border-top: var(--border-width-sm) solid var(--color-border-primary);
-  padding-top: var(--spacing-6);
-  padding-bottom: var(--spacing-8);
+  padding-top: var(--spacing-4);
+  padding-bottom: var(--spacing-5);
   display: flex;
   justify-content: center;
 }


### PR DESCRIPTION
## Summary
- use tighter padding tokens across hero, about, community, roadmap and FAQ sections for consistent vertical rhythm

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a005236a948321b847e85d4328b056