### PR TITLE
refine dark theme colors

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -4,7 +4,7 @@
 }
 
 @mixin gradient-primary {
-  background: linear-gradient(to right, var(--color-indigo-400), var(--color-sky-400));
+  background: var(--gradient-primary);
 }
 
 @mixin text-balance {

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -40,9 +40,10 @@
   --color-emerald-400-rgb: 52, 211, 153;
   
   // Semantic color variables (Dark theme default)
-  --color-background: var(--color-neutral-950);
-  --color-surface-primary: var(--color-neutral-900);
-  --color-surface-secondary: var(--color-neutral-800);
+  // Deeper hues with faint blue/purple accents
+  --color-background: #050510;
+  --color-surface-primary: #0b0b1a;
+  --color-surface-secondary: #141426;
   --color-text-primary: var(--color-neutral-50);
   --color-text-secondary: var(--color-neutral-400);
   --color-text-tertiary: var(--color-neutral-500);
@@ -52,9 +53,16 @@
   --color-accent-secondary: var(--color-sky-400);
   
   // RGB versions for semantic colors
-  --color-background-rgb: var(--color-neutral-950-rgb);
-  --color-surface-primary-rgb: var(--color-neutral-900-rgb);
-  --color-surface-secondary-rgb: var(--color-neutral-800-rgb);
+  --color-background-rgb: 5, 5, 16;
+  --color-surface-primary-rgb: 11, 11, 26;
+  --color-surface-secondary-rgb: 20, 20, 38;
+
+  // Subtle primary gradient
+  --gradient-primary: linear-gradient(
+    135deg,
+    rgba(var(--color-indigo-500-rgb), 0.25),
+    rgba(var(--color-sky-500-rgb), 0.25)
+  );
   
   // Spacing scale (based on 0.25rem = 4px)
   --spacing-0-25: 0.25rem;   // 4px
@@ -163,7 +171,7 @@ html {
     background-position: 0% 50%;
   }
   50% {
-    background-position: 100% 50%;
+    background-position: 50% 50%;
   }
   100% {
     background-position: 0% 50%;


### PR DESCRIPTION
## Summary
- deepen dark theme background and surface tones with blue/purple tint
- provide subtle gradient utilities for calmer movement
- introduce gradient variable for reusability

## Testing
- `npm run lint`
- `npm test`
- `node -e "function lum(c){c=c.replace('#','');let r=parseInt(c.substr(0,2),16)/255,g=parseInt(c.substr(2,2),16)/255,b=parseInt(c.substr(4,2),16)/255;[r,g,b]=[r,g,b].map(v=>v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4));return 0.2126*r+0.7152*g+0.0722*b;} function contrast(c1,c2){let L1=lum(c1),L2=lum(c2);if(L1<L2){[L1,L2]=[L2,L1];}return (L1+0.05)/(L2+0.05);} console.log('bg vs text',contrast('#050510','#fafafa').toFixed(2)); console.log('surface1 vs text',contrast('#0b0b1a','#fafafa').toFixed(2)); console.log('surface2 vs textSecondary',contrast('#141426','#a1a1aa').toFixed(2));"`

------
https://chatgpt.com/codex/tasks/task_e_68a005265f808321933f80a700e3eb4a