### PR TITLE
Clean up timeout and improve 3D background fallback

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -264,7 +264,7 @@ export default function NorthLabComingSoon() {
 
     gsap.ticker.lagSmoothing(0);
 
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       setIsLoaded(true);
       if (!prefersReducedMotion) {
         initScrollAnimations();
@@ -272,6 +272,7 @@ export default function NorthLabComingSoon() {
     }, 300);
 
     return () => {
+      clearTimeout(timeoutId);
       lenis.destroy();
       ScrollTrigger.getAll().forEach(trigger => trigger.kill());
     };

--- a/src/components/ThreeDBackground/ThreeDBackground.test.tsx
+++ b/src/components/ThreeDBackground/ThreeDBackground.test.tsx
@@ -4,8 +4,11 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import { ThreeDBackground } from './ThreeDBackground';
 import styles from './ThreeDBackground.module.scss';
+
+vi.mock('./ThreeDBackgroundCanvas', () => new Promise(() => {}));
+
+import { ThreeDBackground } from './ThreeDBackground';
 
 describe('ThreeDBackground', () => {
   it('omits canvas and shows gradient overlay when prefersReducedMotion is true', async () => {
@@ -31,5 +34,23 @@ describe('ThreeDBackground', () => {
 
     const noise = container.querySelector(`.${styles.noiseFallback}`);
     expect(noise).not.toBeNull();
+  });
+
+  it('renders fallback and overlay while the canvas is loading', () => {
+    Object.defineProperty(window, 'WebGLRenderingContext', {
+      value: function () {},
+      writable: true,
+    });
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({});
+
+    const { container } = render(
+      <ThreeDBackground mouseX={0} mouseY={0} />
+    );
+
+    const noise = container.querySelector(`.${styles.noiseFallback}`);
+    expect(noise).not.toBeNull();
+
+    const overlay = container.querySelector(`.${styles.overlay}`);
+    expect(overlay).not.toBeNull();
   });
 });

--- a/src/components/ThreeDBackground/ThreeDBackground.tsx
+++ b/src/components/ThreeDBackground/ThreeDBackground.tsx
@@ -50,7 +50,7 @@ export const ThreeDBackground: React.FC<ThreeDBackgroundProps> = ({
   return (
     <div className={styles.backgroundContainer}>
       {shouldRenderCanvas ? (
-        <Suspense fallback={null}>
+        <Suspense fallback={<div className={styles.noiseFallback} />}>
           <ThreeDCanvas
             mouseX={mouseX}
             mouseY={mouseY}


### PR DESCRIPTION
## Summary
- clear homepage timeout on unmount to avoid dangling timer
- show noisy background while 3D canvas loads and keep overlay visible
- test that Suspense fallback renders noise and overlay

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0cfd058388321827a7fbfec24d030