### PR TITLE
feat: add client email validation and accessible status

### DIFF
--- a/src/components/WaitlistForm/__tests__/WaitlistForm.test.tsx
+++ b/src/components/WaitlistForm/__tests__/WaitlistForm.test.tsx
@@ -61,6 +61,19 @@ describe('WaitlistForm', () => {
     expect(document.activeElement).toBe(input);
   });
 
+  it('validates email format client-side', async () => {
+    render(<WaitlistForm />);
+
+    const input = screen.getByLabelText('Email address');
+    const form = input.closest('form')!;
+    fireEvent.change(input, { target: { value: 'invalid-email' } });
+    fireEvent.submit(form);
+
+    await screen.findByText('Please enter a valid email address.');
+    expect(addEmailToWaitlist).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
+  });
+
   it('focuses input and enables button on network error', async () => {
     addEmailToWaitlist.mockRejectedValueOnce(new Error('network'));
 


### PR DESCRIPTION
## Summary
- validate email format on the client before contacting the waitlist service
- announce waitlist form messages to screen readers with `role="status"` and `aria-live="polite"`
- test invalid email handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0cfd1056083219a0c56e81597e985