### PR TITLE
Improve SVG accessibility and remove redundant aria label

### DIFF
--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -50,7 +50,6 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
                 globalRotateY * -0.2
               }deg) translateZ(10px)`,
             }}
-            aria-label="NorthLab is a place where your craft, your ideas, and your ambition get the clarity they deserve. Built for people who choose their own path, not the one handed to them."
           >
             <span className="line">
               NorthLab is a place where your craft, your ideas, and your

--- a/src/components/NorthLabLockup.test.tsx
+++ b/src/components/NorthLabLockup.test.tsx
@@ -17,4 +17,13 @@ describe('NorthLabLockup', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
+  it('is hidden from assistive tech when no aria label', async () => {
+    const { container } = render(<NorthLabLockup />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.getAttribute('focusable')).toBe('false');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });

--- a/src/components/NorthLabLockup.tsx
+++ b/src/components/NorthLabLockup.tsx
@@ -14,6 +14,8 @@ export const NorthLabLockup: React.FC<NorthLabLockupProps> = ({
     <svg
       role={ariaLabel ? 'img' : undefined}
       aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+      focusable={ariaLabel ? undefined : false}
       width="389.18"
       height="57.12"
       viewBox="0.34 0.88 389.18 57.12"


### PR DESCRIPTION
## Summary
- Hide `NorthLabLockup` SVG from assistive tech when no aria label
- Remove redundant aria-label from HeroSection description
- Add test coverage for decorative `NorthLabLockup`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0cfd1bbbc83219c1b69cf4ff57194