### PR TITLE
Replace svg icons with heroicons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@react-three/drei": "^9.88.13",
         "@react-three/fiber": "^8.15.11",
         "@studio-freight/lenis": "^1.0.42",
         "@supabase/supabase-js": "^2.55.0",
         "gsap": "^3.13.0",
-        "lucide-react": "^0.344.0",
         "next": "^14.2.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -779,6 +779,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4309,14 +4318,6 @@
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.344.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.344.0.tgz",
-      "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@react-three/drei": "^9.88.13",
     "@react-three/fiber": "^8.15.11",
     "@studio-freight/lenis": "^1.0.42",
     "@supabase/supabase-js": "^2.55.0",
     "gsap": "^3.13.0",
-    "lucide-react": "^0.344.0",
     "next": "^14.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/AboutSection/AboutSection.tsx
+++ b/src/components/AboutSection/AboutSection.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
-import { Users, Shield, Zap, ArrowUpRight } from 'lucide-react';
+import {
+  UserGroupIcon,
+  ShieldCheckIcon,
+  BoltIcon,
+  ArrowUpRightIcon,
+} from '@heroicons/react/24/outline';
 import { Container } from '../Container/Container';
 import { aboutContent } from '../../data/content';
 import styles from './AboutSection.module.scss';
 
 // Icon mapping for dynamic icon rendering
 const iconMap = {
-  Users,
-  Shield,
-  Zap
+  Users: UserGroupIcon,
+  Shield: ShieldCheckIcon,
+  Zap: BoltIcon,
 };
 
 interface AboutSectionProps {
@@ -18,7 +23,7 @@ interface AboutSectionProps {
 export const AboutSection: React.FC<AboutSectionProps> = ({ aboutRef }) => {
   const getIcon = (iconName: string) => {
     const IconComponent = iconMap[iconName as keyof typeof iconMap];
-    return IconComponent ? <IconComponent size={24} /> : null;
+    return IconComponent ? <IconComponent width={24} height={24} /> : null;
   };
 
   return (
@@ -48,7 +53,7 @@ export const AboutSection: React.FC<AboutSectionProps> = ({ aboutRef }) => {
               <h3 className={styles.benefitTitle}>{benefit.title}</h3>
               <p className={styles.benefitDescription}>{benefit.description}</p>
               <div className={styles.benefitArrow}>
-                <ArrowUpRight size={20} />
+                <ArrowUpRightIcon width={20} height={20} />
               </div>
             </div>
           ))}

--- a/src/components/FAQSection/FAQSection.tsx
+++ b/src/components/FAQSection/FAQSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import { Container } from '../Container/Container';
 import { faqContent } from '../../data/content';
 import styles from './FAQSection.module.scss';
@@ -20,9 +20,10 @@ const FAQItem: React.FC<FAQItemProps> = ({ question, answer, isOpen, onToggle })
         aria-expanded={isOpen}
       >
         <span className={styles.faqQuestion}>{question}</span>
-        <ChevronDown 
+        <ChevronDownIcon
           className={`${styles.faqIcon} ${isOpen ? styles.rotated : ''}`}
-          size={20}
+          width={20}
+          height={20}
         />
       </button>
       <div className={`${styles.faqAnswer} ${isOpen ? styles.expanded : ''}`}>


### PR DESCRIPTION
## Summary
- replace lucide-react icons with @heroicons/react and remove unused lucide-react dependency
- swap FAQ and About section icons to heroicons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0ede04d408321a6bc0d5b0ee368c1